### PR TITLE
Normalize subpaths' bounds before taking their union

### DIFF
--- a/SVGBezierPath.mm
+++ b/SVGBezierPath.mm
@@ -214,7 +214,10 @@ extern "C" CGRect SVGBoundingRectForPaths(NSArray<SVGBezierPath*> * const paths)
 {
     CGRect bounds = CGRectZero;
     for(SVGBezierPath *path in paths) {
-        bounds = CGRectUnion(bounds, path.bounds);
+        CGRect pathBounds = CGRectStandardize(path.bounds);
+        if (!(CGRectIsEmpty(pathBounds) || CGRectIsInfinite(pathBounds))) {
+            bounds = CGRectUnion(bounds, pathBounds);
+        }
     }
     return bounds;
 }


### PR DESCRIPTION
Hm, after finding https://github.com/ScentreGroup/PocketSVG/pull/2, maybe that was actually the case of this problem and this papering-over of it is not necessary.